### PR TITLE
Fix BlueZ MTU Size Error

### DIFF
--- a/src/frame_sdk/bluetooth.py
+++ b/src/frame_sdk/bluetooth.py
@@ -234,6 +234,10 @@ class Bluetooth:
             self._TX_CHARACTERISTIC_UUID,
         )
 
+        client_name = self._btle_client._backend.__class__.__name__
+        if client_name == "BleakClientBlueZDBus":
+            await self._btle_client._backend._acquire_mtu()
+
     async def disconnect(self) -> None:
         """
         Disconnects from the device.


### PR DESCRIPTION
There seems to be a long running issue with Bleak and the default bluetooth stack on Linux BlueZ, where the MTU size isn't set correctly.

With respect to the Frame SDK, without correcting for MTU size, usually generates a `Payload length is too large` exception.

I appreciate this is a pretty specific use case, but there doesn't seem to be way to easily do this on the user side, rather than modifying the library. Largely because the `__aenter__` method both connects, and attempts to inject the library functions, which will fail if the MTU size is incorrect.

Mirrors suggestion by Bleak maintainers in `bleak/examples/mtu_size.py`, and is a little more reliable than adding a hard coded mtu size.

Targets issue #1.